### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,6 @@ setup(name="pyrecon",
       scripts=['scripts/meld_info', 'scripts/wall_info',
                'scripts/wall2meld', 'scripts/dsres2meld'],
       packages=['recon'],
+      install_requires=['msgpack-python'],
       include_package_data=True,
       zip_safe=False)


### PR DESCRIPTION
added Msgpack to required dependencies

My test on WinXP:
1. Clean install of python-2.7.6.msi
2. Install of setuptools-2.2.win32-py2.7.exe from http://www.lfd.uci.edu/~gohlke/pythonlibs/#setuptools
3. Try to run setup.py install -> Run into http://bugs.python.org/issue9291 -> Used workaround http://bugs.python.org/issue9291#msg206938
4. Try again to run setup.py install -> Run into issue http://stackoverflow.com/questions/20709641/cant-compile-msgpack-python-extension-under-windows -> Used workaround from http://www.borgelt.net/pycoco.html, i.e. typed
   SET VS90COMNTOOLS=%VS100COMNTOOLS%
   on cmd line to change compiler from VS2008 to VS2010.
5. Try again to run setup.py install -> Compilation succeeds (with warnings) and setup is finished
