### PR TITLE
Don't crash reader in case of recovarable errors

### DIFF
--- a/recon/wall.py
+++ b/recon/wall.py
@@ -514,7 +514,11 @@ class WallTableReader(object):
         """
         Aliases in this table
         """
-        return self.header[T_ALIASES].keys()
+        if not T_ALIASES in self.header:
+            print "WARNING: Alias information is missing from table '%s'" % (self.name)
+            return set()
+        else:
+            return self.header[T_ALIASES].keys()
 
     def variables(self):
         """

--- a/recon/wall.py
+++ b/recon/wall.py
@@ -498,8 +498,19 @@ class WallTableReader(object):
         self.reader = reader
         self.name = name
         self.header = header
-        self.metadata = self.header[T_METADATA]
         self.var_metadata = self.header[T_VMETADATA]
+        self.metadata = self.get_metadata()
+
+    def get_metadata(self):
+        """
+        Metadata in this table
+        """
+        if not T_METADATA in self.header:
+            print "WARNING: Metadata information is missing from table '%s'" % (self.name)
+            return set()
+        else:
+            return self.header[T_METADATA]
+
     def signals(self):
         """
         Signals in this table

--- a/recon/wall.py
+++ b/recon/wall.py
@@ -498,8 +498,18 @@ class WallTableReader(object):
         self.reader = reader
         self.name = name
         self.header = header
-        self.var_metadata = self.header[T_VMETADATA]
+        self.var_metadata = self.get_var_metadata()
         self.metadata = self.get_metadata()
+
+    def get_var_metadata(self):
+        """
+        Variable-Metadata in this table
+        """
+        if not T_VMETADATA in self.header:
+            print "WARNING: Variable-Metadata information is missing from table '%s'" % (self.name)
+            return set()
+        else:
+            return self.header[T_VMETADATA]
 
     def get_metadata(self):
         """

--- a/recon/wall.py
+++ b/recon/wall.py
@@ -504,7 +504,11 @@ class WallTableReader(object):
         """
         Signals in this table
         """
-        return self.header[T_SIGNALS]
+        if not T_SIGNALS in self.header:
+            print "WARNING: Signal information is missing from table '%s'" % (self.name)
+            return set()
+        else:
+            return self.header[T_SIGNALS]
 
     def aliases(self):
         """


### PR DESCRIPTION
These cases might be in violation of the specification, but since all these fields may have a safe default (i.e. the empty case), it is trivial to support their absence. 

I copied the warning behaviour from the fields that already might be absent (e.g. objects).
